### PR TITLE
Update crossterm dependency to use use-dev-tty feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ codegen-units = 1
 
 [dependencies]
 chrono = "0.4.42"
-crossterm = { version = "0.29.0", default-features = false, features = ["events", "bracketed-paste", "windows", "filedescriptor"] }
+crossterm = { version = "0.29.0", default-features = false, features = ["bracketed-paste", "events", "use-dev-tty", "windows"] }
 portable-pty = "0.9"
 vte = "0.15"
 libc = "0.2"


### PR DESCRIPTION
See https://github.com/crossterm-rs/crossterm/pull/1101